### PR TITLE
add version to inter.css

### DIFF
--- a/inter.css
+++ b/inter.css
@@ -3,16 +3,16 @@
   font-style:  normal;
   font-weight: 100;
   font-display: swap;
-  src: url("Inter Web/Inter-Thin.woff2") format("woff2"),
-       url("Inter Web/Inter-Thin.woff") format("woff");
+  src: url("Inter Web/Inter-Thin.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-Thin.woff?v=3.18") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 100;
   font-display: swap;
-  src: url("Inter Web/Inter-ThinItalic.woff2") format("woff2"),
-       url("Inter Web/Inter-ThinItalic.woff") format("woff");
+  src: url("Inter Web/Inter-ThinItalic.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-ThinItalic.woff?v=3.18") format("woff");
 }
 
 @font-face {
@@ -20,16 +20,16 @@
   font-style:  normal;
   font-weight: 200;
   font-display: swap;
-  src: url("Inter Web/Inter-ExtraLight.woff2") format("woff2"),
-       url("Inter Web/Inter-ExtraLight.woff") format("woff");
+  src: url("Inter Web/Inter-ExtraLight.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-ExtraLight.woff?v=3.18") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 200;
   font-display: swap;
-  src: url("Inter Web/Inter-ExtraLightItalic.woff2") format("woff2"),
-       url("Inter Web/Inter-ExtraLightItalic.woff") format("woff");
+  src: url("Inter Web/Inter-ExtraLightItalic.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-ExtraLightItalic.woff?v=3.18") format("woff");
 }
 
 @font-face {
@@ -37,16 +37,16 @@
   font-style:  normal;
   font-weight: 300;
   font-display: swap;
-  src: url("Inter Web/Inter-Light.woff2") format("woff2"),
-       url("Inter Web/Inter-Light.woff") format("woff");
+  src: url("Inter Web/Inter-Light.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-Light.woff?v=3.18") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 300;
   font-display: swap;
-  src: url("Inter Web/Inter-LightItalic.woff2") format("woff2"),
-       url("Inter Web/Inter-LightItalic.woff") format("woff");
+  src: url("Inter Web/Inter-LightItalic.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-LightItalic.woff?v=3.18") format("woff");
 }
 
 @font-face {
@@ -54,16 +54,16 @@
   font-style:  normal;
   font-weight: 400;
   font-display: swap;
-  src: url("Inter Web/Inter-Regular.woff2") format("woff2"),
-       url("Inter Web/Inter-Regular.woff") format("woff");
+  src: url("Inter Web/Inter-Regular.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-Regular.woff?v=3.18") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 400;
   font-display: swap;
-  src: url("Inter Web/Inter-Italic.woff2") format("woff2"),
-       url("Inter Web/Inter-Italic.woff") format("woff");
+  src: url("Inter Web/Inter-Italic.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-Italic.woff?v=3.18") format("woff");
 }
 
 @font-face {
@@ -71,16 +71,16 @@
   font-style:  normal;
   font-weight: 500;
   font-display: swap;
-  src: url("Inter Web/Inter-Medium.woff2") format("woff2"),
-       url("Inter Web/Inter-Medium.woff") format("woff");
+  src: url("Inter Web/Inter-Medium.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-Medium.woff?v=3.18") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 500;
   font-display: swap;
-  src: url("Inter Web/Inter-MediumItalic.woff2") format("woff2"),
-       url("Inter Web/Inter-MediumItalic.woff") format("woff");
+  src: url("Inter Web/Inter-MediumItalic.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-MediumItalic.woff?v=3.18") format("woff");
 }
 
 @font-face {
@@ -88,16 +88,16 @@
   font-style:  normal;
   font-weight: 600;
   font-display: swap;
-  src: url("Inter Web/Inter-SemiBold.woff2") format("woff2"),
-       url("Inter Web/Inter-SemiBold.woff") format("woff");
+  src: url("Inter Web/Inter-SemiBold.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-SemiBold.woff?v=3.18") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 600;
   font-display: swap;
-  src: url("Inter Web/Inter-SemiBoldItalic.woff2") format("woff2"),
-       url("Inter Web/Inter-SemiBoldItalic.woff") format("woff");
+  src: url("Inter Web/Inter-SemiBoldItalic.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-SemiBoldItalic.woff?v=3.18") format("woff");
 }
 
 @font-face {
@@ -105,16 +105,16 @@
   font-style:  normal;
   font-weight: 700;
   font-display: swap;
-  src: url("Inter Web/Inter-Bold.woff2") format("woff2"),
-       url("Inter Web/Inter-Bold.woff") format("woff");
+  src: url("Inter Web/Inter-Bold.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-Bold.woff?v=3.18") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 700;
   font-display: swap;
-  src: url("Inter Web/Inter-BoldItalic.woff2") format("woff2"),
-       url("Inter Web/Inter-BoldItalic.woff") format("woff");
+  src: url("Inter Web/Inter-BoldItalic.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-BoldItalic.woff?v=3.18") format("woff");
 }
 
 @font-face {
@@ -122,16 +122,16 @@
   font-style:  normal;
   font-weight: 800;
   font-display: swap;
-  src: url("Inter Web/Inter-ExtraBold.woff2") format("woff2"),
-       url("Inter Web/Inter-ExtraBold.woff") format("woff");
+  src: url("Inter Web/Inter-ExtraBold.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-ExtraBold.woff?v=3.18") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 800;
   font-display: swap;
-  src: url("Inter Web/Inter-ExtraBoldItalic.woff2") format("woff2"),
-       url("Inter Web/Inter-ExtraBoldItalic.woff") format("woff");
+  src: url("Inter Web/Inter-ExtraBoldItalic.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-ExtraBoldItalic.woff?v=3.18") format("woff");
 }
 
 @font-face {
@@ -139,16 +139,16 @@
   font-style:  normal;
   font-weight: 900;
   font-display: swap;
-  src: url("Inter Web/Inter-Black.woff2") format("woff2"),
-       url("Inter Web/Inter-Black.woff") format("woff");
+  src: url("Inter Web/Inter-Black.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-Black.woff?v=3.18") format("woff");
 }
 @font-face {
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 900;
   font-display: swap;
-  src: url("Inter Web/Inter-BlackItalic.woff2") format("woff2"),
-       url("Inter Web/Inter-BlackItalic.woff") format("woff");
+  src: url("Inter Web/Inter-BlackItalic.woff2?v=3.18") format("woff2"),
+       url("Inter Web/Inter-BlackItalic.woff?v=3.18") format("woff");
 }
 
 /* -------------------------------------------------------
@@ -166,7 +166,7 @@ Usage:
   font-display: swap;
   font-style: normal;
   font-named-instance: 'Regular';
-  src: url("Inter Web/Inter-roman.var.woff2") format("woff2");
+  src: url("Inter Web/Inter-roman.var.woff2?v=3.18") format("woff2");
 }
 @font-face {
   font-family: 'Inter var';
@@ -174,7 +174,7 @@ Usage:
   font-display: swap;
   font-style: italic;
   font-named-instance: 'Italic';
-  src: url("Inter Web/Inter-italic.var.woff2") format("woff2");
+  src: url("Inter Web/Inter-italic.var.woff2?v=3.18") format("woff2");
 }
 
 
@@ -196,5 +196,5 @@ explicitly, e.g.
   font-weight: 100 900;
   font-display: swap;
   font-style: oblique 0deg 10deg;
-  src: url("Inter Web/Inter.var.woff2") format("woff2");
+  src: url("Inter Web/Inter.var.woff2?v=3.18") format("woff2");
 }


### PR DESCRIPTION
Relates to https://github.com/ajmalafif/typeface-inter/issues/7

Adds the version to the source URLs in the main `inter.css` file, same as what exists in the other CSS file under the Hinted for Windows directory. This ensures the fonts are updated in the browser when there is a new version (browser caches latest version).